### PR TITLE
Update ngScrollSpy.js

### DIFF
--- a/dist/ngScrollSpy.js
+++ b/dist/ngScrollSpy.js
@@ -379,7 +379,7 @@ mod.directive('pageitems', function(ScrollSpy) {
 				}
 
 				var pos = spyElem.getBoundingClientRect().top;
-				if (pos <= topmargin) {
+				if (Math.floor(pos) <= topmargin) {
 					// the window has been scrolled past the top of a spy element
 					spy.pos = pos;
 


### PR DESCRIPTION
Method getBoundingClientRect().top in Firefox returns float values. For example,  20.26666259765625. And condition in line 382 is wrong because of it.